### PR TITLE
Fix typo in node.py

### DIFF
--- a/p2pnetwork/node.py
+++ b/p2pnetwork/node.py
@@ -36,7 +36,7 @@ class Node(threading.Thread):
            provide a callback method. It is preferred to implement a new node by extending this Node class. 
             host: The host name or ip address that is used to bind the TCP/IP server to.
             port: The port number that is used to bind the TCP/IP server to.
-            id: (optional) This id will be assiocated with the node. When not given a unique ID will be created.
+            id: (optional) This id will be associated with the node. When not given a unique ID will be created.
             callback: (optional) The callback that is invokes when events happen inside the network.
             max_connections: (optional) limiting the maximum nodes that are able to connect to this node."""
         super(Node, self).__init__()


### PR DESCRIPTION
Line 39. Change `assiocated` to `associated`.