### PR TITLE
Allow ids to have colons

### DIFF
--- a/p2pnetwork/node.py
+++ b/p2pnetwork/node.py
@@ -266,7 +266,7 @@ class Node(threading.Thread):
                     connected_node_port = client_address[1] # backward compatibilty
                     connected_node_id   = connection.recv(4096).decode('utf-8')
                     if ":" in connected_node_id:
-                        (connected_node_id, connected_node_port) = connected_node_id.split(':') # When a node is connected, it sends it id!
+                        (connected_node_id, connected_node_port) = connected_node_id.rsplit(':', 1) # When a node is connected, it sends it id!
                     connection.send(self.id.encode('utf-8')) # Send my id to the connected node!
 
                     thread_client = self.create_new_connection(connection, connected_node_id, client_address[0], connected_node_port)


### PR DESCRIPTION
When receiving id:port on initial connection, use rsplit(':', -1) instead of split (':') so ids with colons won't cause errors