### PR TITLE
Allow for easy imports

### DIFF
--- a/p2pnetwork/__init__.py
+++ b/p2pnetwork/__init__.py
@@ -10,4 +10,7 @@ __author__ = 'Maurice Snoeren'
 __license__ = "GNU 3.0"
 __main__ = "p2pnetwork"
 
-__all__ = ["node", "nodeconnection"]
+__all__ = ["Node", "NodeConnection"]
+
+from .node import Node
+from .nodeconection import NodeConnection

--- a/p2pnetwork/__init__.py
+++ b/p2pnetwork/__init__.py
@@ -10,7 +10,7 @@ __author__ = 'Maurice Snoeren'
 __license__ = "GNU 3.0"
 __main__ = "p2pnetwork"
 
-__all__ = ["Node", "NodeConnection"]
+__all__ = ["node", "Node", "nodeconnection", "NodeConnection"]
 
 from .node import Node
 from .nodeconection import NodeConnection


### PR DESCRIPTION
I changed the __all__ list and imported the objects from the individual files to make importing easier. Now it is possible to do something like this:
```
from p2pnetwork import Node, NodeConnection
```
Hope this can help to contribute!