### PR TITLE
Modify README.md to where the initialization of the Node class has the callback set properly instead of being set as the ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ def node_callback(event, node, connected_node, data):
 
 # The main node that is able to make connections to other nodes
 # and accept connections from other nodes on port 8001.
-node = Node("127.0.0.1", 10001, node_callback)
+node = Node("127.0.0.1", 10001, callback=node_callback)
 
 # Do not forget to start it, it spins off a new thread!
 node.start()


### PR DESCRIPTION
On line 162 of the README.md, when it defines a node, it does not specify the node_callback function as the callback, instead setting it sets it as the ID.